### PR TITLE
Added log level option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ node-named uses [http://github.com/trentm/node-bunyan](bunyan) for logging.
 It's a lot nicer to use if you npm install bunyan and put the bunyan tool in
 your path. Otherwise, you will end up with JSON formatted log output by default.
 
+If you wish to set the log level that bunyan uses supply a log option when
+creating the server, like this:
+
+
+```javascript
+var named = require('./lib/index');
+var server = named.createServer({
+	log: 'error'
+});
+```
+
 ### Replacing the default logger
 
 You can pass in an alternate logger if you wish. If you do not, then it will use

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,12 +36,25 @@ module.exports = {
 
                 var opts = {
                         name: options.name || 'named',
-                        log: options.log || bunyan.createLogger({
+                };
+                if (typeof (options.log) === 'object') {
+                        // An alternative logger has been specified
+                        opts.log = options.log
+                } else if (typeof (options.log) === 'string') {
+                        // A log level has been specified
+                        opts.log = bunyan.createLogger({
+                                name: 'named',
+                                level: options.log,
+                                serializers: BUNYAN_SERIALIZERS
+                        });
+                } else {
+                        // No or unrecognised logger has been specified - use default
+                        opts.log = bunyan.createLogger({
                                 name: 'named',
                                 level: 'warn',
                                 serializers: BUNYAN_SERIALIZERS
-                        })
-                };
+                        });
+                }
                 return (new Server(opts));
         },
 


### PR DESCRIPTION
Thanks for this great library! I am using this to serve custom records for our small office and it's proving far superior to the original bind9 solution!

I needed to 'synchronise' the log level of node-named with the app's own logging so I made a short change to the createServer() function. Let me know what you think, this is my first pull request and I tried to maintain conventions.