### PR TITLE
Dynamically detect v4/v6

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -16,6 +16,11 @@ var ExceptionError = DnsError.ExceptionError;
 var ProtocolError = DnsError.ProtocolError;
 
 
+///--- IP regex
+
+const ip4re = /^(\d{1,3}\.){3,3}\d{1,3}$/
+const ip6re = /^(::)?(((\d{1,3}\.){3}(\d{1,3}){1})?([0-9a-f]){0,4}:{0,2}){1,8}(::)?$/i
+
 
 ///--- API
 
@@ -48,9 +53,16 @@ Server.prototype.listen = function listen(port, address, callback) {
                 address = '0.0.0.0';
         }
 
+        let fam = ''
+
+        if (address.match(ip4re)) fam = 'udp4'
+        if (!fam && address.match(ip6re)) fam = 'udp6'
+
+        if (!fam) throw new TypeError('IP is neither valid v4 or v6')
+
         var self = this;
 
-        this._socket = dgram.createSocket('udp6');
+        this._socket = dgram.createSocket(fam);
         this._socket.once('listening', function () {
                 self.emit('listening');
                 if (typeof (callback) === 'function')
@@ -71,7 +83,7 @@ Server.prototype.listen = function listen(port, address, callback) {
                 };
 
                 var src = {
-                        family: 'udp6',
+                        family: fam,
                         address: rinfo.address,
                         port: rinfo.port
                 };


### PR DESCRIPTION
By default an IPv6-only socket is created which makes it impossible to use this server with IPv4 hosts.
I've added a bit of code that checks the IP version via regex and creates the appropriate socket for it