### PR TITLE
Add PTR records and fix up "make test"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NODEUNIT 	:= ./node_modules/.bin/nodeunit
-BUNYAN 		:= ./node_modules/.bin/bunyan
+BUNYAN 		:= ./node_modules/bunyan/bin/bunyan
 NPM 		:= $(shell which npm)
 
 .PHONY: setup

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ I've received a lot of great PRs for this project, but I don't have the capacity
 
 node-named provides helper functions for creating DNS records. 
 The records are available under 'named.record.NAME' where NAME is one
-of ['A', 'AAAA', 'CNAME', 'SOA', 'MX', 'NS', 'TXT, 'SRV']. It is important to 
+of ['A', 'AAAA', 'CNAME', 'SOA', 'MX', 'NS', 'TXT', 'PTR', 'SRV']. It is important to 
 remember that these DNS records are not permanently added to the server. 
 They only exist for the length of the particular request. After that, they are
 destroyed. This means you have to create your own lookup mechanism.

--- a/examples/reflect.js
+++ b/examples/reflect.js
@@ -26,6 +26,10 @@ server.on('query', function(query) {
                 var record = new named.MXRecord('smtp.example.com');
                 query.addAnswer(domain, record, 300);
                 break;
+        case 'PTR':
+                var record = new named.PTRRecord('rdns.example.com');
+                query.addAnswer(domain, record, 300);
+                break;
         case 'SOA':
                 var record = new named.SOARecord('example.com');
                 query.addAnswer(domain, record, 300);

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -288,9 +288,8 @@ var serializers = {
                                 r = serializers['_nsIP4'].encoder(v.target);
                                 break;
                         case queryTypes['CNAME']:
-                                r = serializers['_nsName'].encoder(v.target);
-                                break;
                         case queryTypes['NS']:
+                        case queryTypes['PTR']:
                                 r = serializers['_nsName'].encoder(v.target);
                                 break;
                         case queryTypes['SOA']:

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var net = require('net');
 var dgram = require('dgram');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
@@ -6,7 +7,9 @@ var util = require('util');
 var Query = require('./query');
 var DnsError = require('./errors');
 
-
+function getFamily(ipVersion) {
+  return (ipVersion == 4) ? 'udp4' : 'udp6';
+}
 
 ///--- Globals
 
@@ -50,7 +53,13 @@ Server.prototype.listen = function listen(port, address, callback) {
 
         var self = this;
 
-        this._socket = dgram.createSocket('udp6');
+        var ip_version = net.isIP(address);
+        var ip_family = getFamily(ip_version);
+
+        if (!ip_version)
+            self.emit('error', new Error("Invalid IP address"));
+
+        this._socket = dgram.createSocket(ip_family);
         this._socket.once('listening', function () {
                 self.emit('listening');
                 if (typeof (callback) === 'function')
@@ -71,7 +80,7 @@ Server.prototype.listen = function listen(port, address, callback) {
                 };
 
                 var src = {
-                        family: 'udp6',
+                        family: ip_family,
                         address: rinfo.address,
                         port: rinfo.port
                 };

--- a/test/named.test.js
+++ b/test/named.test.js
@@ -49,6 +49,10 @@ before(function (callback) {
                         var record = new named.MXRecord('smtp.example.com');
                         query.addAnswer(domain, record);
                         break;
+                case 'PTR':
+                        var record = new named.PTRRecord('rdns.example.com');
+                        query.addAnswer(domain, record);
+                        break;
                 case 'SOA':
                         var record = new named.SOARecord('example.com');
                         query.addAnswer(domain, record);
@@ -168,6 +172,19 @@ test('answer query: example.com (MX)', function (t) {
 });
 
 
+test('answer query: example.com (PTR)', function (t) {
+        dig('1.0.0.127.in-addr.arpa', 'PTR', options, function (err, results) {
+                t.ifError(err);
+                t.deepEqual(results.answers, [{
+                        name: '1.0.0.127.in-addr.arpa.',
+                        ttl: 5,
+                        type: 'PTR',
+                        target: 'rdns.example.com.'
+                }]);
+                t.end();
+        });
+});
+
 test('answer query: example.com (SOA)', function (t) {
         dig('example.com', 'SOA', options, function (err, results) {
                 t.ifError(err);
@@ -180,7 +197,6 @@ test('answer query: example.com (SOA)', function (t) {
                 t.end();
         });
 });
-
 
 test('answer query: example.com (SRV)', function (t) {
         dig('_sip._tcp.example.com', 'SRV', options, function (err, results) {

--- a/test/records.test.js
+++ b/test/records.test.js
@@ -45,6 +45,11 @@ test('create a valid record (MX)', function(t) {
         testRecord(record, t);
 });
 
+test('create a valid record (PTR)', function(t) {
+        var record = new named.PTRRecord('rdns.example.com');
+        testRecord(record, t);
+});
+
 test('create a valid record (SOA)', function(t) {
         var record = new named.SOARecord('example.com');
         testRecord(record, t);


### PR DESCRIPTION
Turns out when on my version of NodeJS (or the version of bunyan I got?) `make test` errors out because `./node_modules/.bin/bunyan` is a shell wrapper script around the actual JavaScript file.
Edited it to a version that should work always (`./node_modules/bunyan/bin/bunyan`).

Also added PTR records and tests for them.

This PR includes the "auto v4/v6 detection" PR as I couldn't get it to run otherwise for testing.