### PR TITLE
Fixed malformed response from bad ARCOUNT

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -72,8 +72,10 @@ Query.prototype.encode = function encode() {
                         flags: this._flags,
                         qdCount: this._qdCount,
                         anCount: this._anCount,
-                        nsCount: this._nsCount,
-                        srCount: this._srCount
+                        // nsCount: this._nsCount,
+                        // srCount: this._srCount
+                        nsCount: this._authority ? this._authority.length : 0,
+                        srCount: this._additional ? this._additional.length : 0
                 },
                 question: this._question,
                 answers: this._answers,


### PR DESCRIPTION
_authority and _additional are never filled with data but at response, the corresponding counters are not 0 but contain the counters from the request which will produce a malformed response.

For example, running `dig @127.0.0.1 facebook.com A` would show a warning like this:
`;; Warning: Message parser reports malformed message packet.`
Caused by the fact that at request the ARCOUNT is 1, but at response, there's no Additional Response entries, but the counter is set to 1.